### PR TITLE
Fix for App Builder and other updates

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,70 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [main]
+  schedule:
+    - cron: "17 11 * * 4"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["python"]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://git.io/codeql-language-support
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
+
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
+
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
+
+      #- run: |
+      #   make bootstrap
+      #   make release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,35 @@
+name: Lint Project
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.11']
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+            submodules: recursive
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev,test]
+          pip freeze
+      - name: Lint with pre-commit
+        run: |
+          pre-commit --version
+          pre-commit install
+          pre-commit run --all-files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
   "arrow",
   "black",
+  "debugpy",
   "inflect",
   "isort",
   "paho.mqtt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,6 +121,7 @@ disable = [
   "too-many-arguments",
   "too-many-branches",
   "too-many-instance-attributes",
+  "too-many-lines",
   "too-many-locals",
   "too-many-public-methods",
   "too-many-return-statements",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
   "pydantic<2.0.0",
   "python-dateutil",
   "PyYAML",
-  "redis",
+  "redis<5.0.0",
   "requests",
   "rich",
   "semantic_version",

--- a/release_notes.md
+++ b/release_notes.md
@@ -1,0 +1,20 @@
+# Release Notes
+
+### 1.0.1
+
+-   APP-3915 - [CONFIG] Added validation to ensure displayPath is always in the install.json for API Services
+-   APP-4060 - [CLI] Updated proxy inputs to use environment variables
+-   APP-4077 - [SPEC-TOOL] Updated spec-tool to create an example app_input.py file and to display a mismatch report
+-   APP-4112 - [CONFIG] Updated config submodule (tcex.json model) to support legacy App Builder Apps
+-   APP-4113 - [CONFIG] Updated App Spec model to normalize App features
+
+
+### 1.0.0
+
+-   APP-3926 - Split CLI module of TcEx into tcex-cli project
+-   APP-3912 - [CLI] Updated `tcex` command to use "project.scripts" setting in pyproject.toml
+-   APP-3913 - [DEPS] Updated `deps` command to build **"deps"** or **"lib_"** depending on TcEx version
+-   APP-3819 - [LIST] Updated the `list` to choose the appropriate template branch depending on TcEx version
+-   APP-3820 - [DEPS] Updated the `deps` to choose the appropriate template branch depending on TcEx version
+-   APP-4053 - [CLI] Updated CLI tools to work with changes in App Builder released in ThreatConnect version 7.2
+-   APP-4059 - [CLI] Added proxy support to commands where applicable

--- a/tcex_cli/__metadata__.py
+++ b/tcex_cli/__metadata__.py
@@ -1,3 +1,3 @@
 """TcEx Framework metadata."""
 __license__ = 'Apache-2.0'
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/tcex_cli/cli/cli_abc.py
+++ b/tcex_cli/cli/cli_abc.py
@@ -12,6 +12,7 @@ from semantic_version import Version
 
 # first-party
 from tcex_cli.app.app import App
+from tcex_cli.input.field_type.sensitive import Sensitive
 from tcex_cli.registry import registry
 from tcex_cli.util import Util
 
@@ -39,6 +40,30 @@ class CliABC(ABC):
 
         # register commands
         registry.add_service(App, self.app)
+
+    def _process_proxy_host(self, proxy_host: str | None) -> str | None:
+        """Process proxy host."""
+        os_proxy_host = os.getenv('TC_PROXY_HOST')
+        return proxy_host if proxy_host else os_proxy_host
+
+    def _process_proxy_pass(self, proxy_pass: Sensitive | str | None) -> Sensitive | None:
+        """Process proxy password."""
+        os_proxy_pass = os.getenv('TC_PROXY_PASS') or os.getenv('TC_PROXY_PASSWORD')
+        proxy_pass = proxy_pass if proxy_pass else os_proxy_pass
+        if proxy_pass is not None and not isinstance(proxy_pass, Sensitive):
+            return Sensitive(proxy_pass)
+        return proxy_pass
+
+    def _process_proxy_port(self, proxy_port: int | str | None) -> int | None:
+        """Process proxy port."""
+        os_proxy_port = os.getenv('TC_PROXY_PORT')
+        port = proxy_port if proxy_port else os_proxy_port
+        return int(port) if port is not None else None
+
+    def _process_proxy_user(self, proxy_user: str | None) -> str | None:
+        """Process proxy user."""
+        os_proxy_user = os.getenv('TC_PROXY_USER') or os.getenv('TC_PROXY_USERNAME')
+        return proxy_user if proxy_user else os_proxy_user
 
     @cached_property
     def app(self) -> App:

--- a/tcex_cli/cli/deploy/deploy.py
+++ b/tcex_cli/cli/deploy/deploy.py
@@ -38,6 +38,12 @@ def command(
     * TC_API_PATH
     * TC_API_ACCESS_ID
     * TC_API_SECRET_KEY
+
+    Optional environment variables include:\n
+    * PROXY_HOST\n
+    * PROXY_PORT\n
+    * PROXY_USER\n
+    * PROXY_PASS\n
     """
     cli = DeployCli(
         server,

--- a/tcex_cli/cli/deploy/deploy_cli.py
+++ b/tcex_cli/cli/deploy/deploy_cli.py
@@ -31,15 +31,11 @@ class DeployCli(CliABC):
         self._app_file = app_file
         self.allow_all_orgs = allow_all_orgs
         self.allow_distribution = allow_distribution
-        self.proxy_host = proxy_host
-        self.proxy_port = proxy_port
-        self.proxy_user = proxy_user
+        self.proxy_host = self._process_proxy_host(proxy_host)
+        self.proxy_port = self._process_proxy_port(proxy_port)
+        self.proxy_user = self._process_proxy_user(proxy_user)
         self.proxy_pass = self._process_proxy_pass(proxy_pass)
         self.server = server
-
-    def _process_proxy_pass(self, proxy_pass: str | None) -> Sensitive | None:
-        """Process proxy password."""
-        return None if proxy_pass is None else Sensitive(proxy_pass)
 
     def _check_file(self):
         """Return True if file exists."""
@@ -110,7 +106,13 @@ class DeployCli(CliABC):
             )
 
         else:
-            response_data = response.json()[0]
+            try:
+                response_data = response.json()[0]
+            except IndexError as err:
+                Render.panel.failure(
+                    f'Unexpected response from ThreatConnect API. Failed to deploy App: {err}'
+                )
+
             Render.table.key_value(
                 'Successfully Deployed App',
                 {

--- a/tcex_cli/cli/deps/deps.py
+++ b/tcex_cli/cli/deps/deps.py
@@ -37,7 +37,14 @@ def command(
     proxy_user: StrOrNone = typer.Option(None, help='(Advanced) Username for the proxy server.'),
     proxy_pass: StrOrNone = typer.Option(None, help='(Advanced) Password for the proxy server.'),
 ):
-    """Install dependencies defined in the requirements.txt file."""
+    r"""Install dependencies defined in the requirements.txt file.
+
+    Optional environment variables include:\n
+    * PROXY_HOST\n
+    * PROXY_PORT\n
+    * PROXY_USER\n
+    * PROXY_PASS\n
+    """
     cli = DepsCli(
         app_builder,
         branch,

--- a/tcex_cli/cli/package/package_cli.py
+++ b/tcex_cli/cli/package/package_cli.py
@@ -132,9 +132,12 @@ class PackageCli(CliABC):
         # IMPORTANT:
         # The name of the folder in the zip is the *key* for an App. This
         # value must remain consistent for the App to upgrade successfully.
-        app_name_version = (
-            f'{self.app.tj.model.package.app_name}_{self.app.ij.model.package_version}'
-        )
+        # Normal behavior should be to use the major version with a "v" prefix.
+        # However, some older Apps got released with a non-standard version
+        # (e.g., v2.0). For these Apps the version can be overridden by defining
+        # the "package.app_version" field in the tcex.json file.
+        app_version = self.app.tj.model.package.app_version or self.app.ij.model.package_version
+        app_name_version = f'{self.app.tj.model.package.app_name}_{app_version}'
 
         # build app directory
         app_path_fqpn = self.build_fqpn / app_name_version

--- a/tcex_cli/cli/run/launch_abc.py
+++ b/tcex_cli/cli/run/launch_abc.py
@@ -48,17 +48,17 @@ class LaunchABC(ABC):
         encrypted_data = self.util.encrypt_aes_cbc(key, data)
 
         # ensure that the in directory exists
-        inputs.tc_in_path.mkdir(parents=True, exist_ok=True)
+        inputs.tc_in_path.mkdir(parents=True, exist_ok=True)  # type: ignore
 
         # write the file in/.app_params.json
-        app_params_json = inputs.tc_in_path / '.test_app_params.json'
+        app_params_json = inputs.tc_in_path / '.test_app_params.json'  # type: ignore
         with app_params_json.open(mode='wb') as fh:
             fh.write(encrypted_data)
 
-        # TODO: [high] TEMP - DELETE THIS
-        app_params_json_decrypted = inputs.tc_in_path / '.test_app_params-decrypted.json'
-        with app_params_json_decrypted.open(mode='w') as fh:
-            fh.write(data)
+        # Test code to write decrypted file for debugging
+        # app_params_json_decrypted = inputs.tc_in_path / '.test_app_params-decrypted.json'
+        # with app_params_json_decrypted.open(mode='w') as fh:
+        #     fh.write(data)
 
         # when the App is launched the tcex.input module reads the encrypted
         # file created above # for inputs. in order to decrypt the file, this

--- a/tcex_cli/cli/run/launch_abc.py
+++ b/tcex_cli/cli/run/launch_abc.py
@@ -167,7 +167,6 @@ class LaunchABC(ABC):
             )
         )
 
-    # TODO: [bcs] fix model name :(
     @cached_property
     def session(self) -> TcSession:
         """Return requests Session object for TC admin account."""

--- a/tcex_cli/cli/run/playbook_create.py
+++ b/tcex_cli/cli/run/playbook_create.py
@@ -122,7 +122,7 @@ class BinaryStagger(BaseStagger):
 
     def transform(self) -> str:
         """Return a string value from bytes."""
-        value = base64.b64decode(self.value)
+        value = base64.b64decode(self.value)  # type: ignore
         return base64.b64encode(value).decode('utf-8')
 
 
@@ -148,7 +148,7 @@ class BinaryArrayStagger(BaseStagger):
         """Return a list of string values from a list bytes."""
         values = []
         for v in self.value:
-            v = base64.b64decode(v)
+            v = base64.b64decode(v)  # type: ignore
             values.append(base64.b64encode(v).decode('utf-8'))
 
         return values

--- a/tcex_cli/cli/run/run.py
+++ b/tcex_cli/cli/run/run.py
@@ -24,6 +24,10 @@ def command(
     try:
         cli.update_system_path()
 
+        # validate config.json
+        if not config_json.is_file():
+            Render.panel.failure(f'Config file not found [{config_json}]')
+
         # run in debug mode
         if debug is True:
             cli.debug(debug_port)

--- a/tcex_cli/cli/spec_tool/gen_app_input_static.py
+++ b/tcex_cli/cli/spec_tool/gen_app_input_static.py
@@ -1,7 +1,13 @@
 """TcEx Framework Module"""
 
+# standard library
+from functools import cached_property
+
 # first-party
 from tcex_cli.app.config.install_json import InstallJson
+
+# from tcex_cli.pleb.cached_property import cached_property
+from tcex_cli.render.render import Render
 
 
 class GenAppInputStatic:
@@ -13,38 +19,59 @@ class GenAppInputStatic:
         # class properties
         self.i1 = ' ' * 4
         self.i2 = ' ' * 8
+        self.i3 = ' ' * 12
+        self.i4 = ' ' * 16
         self.ij = InstallJson()
 
-    @property
-    def template_app_inputs_class(self) -> list:
-        """Return app_inputs.py AppInput class."""
-        app_model = 'AppBaseModel'
-        if self.ij.model.is_trigger_app:
-            app_model = 'ServiceConfigModel'
-
-        return [
-            '''class AppInputs:''',
-            f'''{self.i1}"""App Inputs"""''',
-            '',
-            f'''{self.i1}def __init__(self, inputs: 'BaseModel'):''',
-            f'''{self.i2}"""Initialize instance properties."""''',
-            f'''{self.i2}self.inputs = inputs''',
-            '',
-            f'''{self.i1}def update_inputs(self):''',
-            f'''{self.i2}"""Add custom App model to inputs.''',
-            '',
-            f'''{self.i2}Input will be validate when the model is added an any exceptions will''',
-            f'''{self.i2}cause the App to exit with a status code of 1.''',
-            f'''{self.i2}"""''',
-            f'''{self.i2}self.inputs.add_model({app_model})''',
-            '',
-            '',
-        ]
+    @cached_property
+    def app_base_model_class(self) -> str:
+        """Return App Base Model class."""
+        _class, _ = self.app_base_model_data
+        return _class
 
     @property
     def app_base_model_class_comment(self) -> str:
         """Return Service Config Model class."""
         return f'{self.i1}"""Base model for the App containing any common inputs."""'
+
+    @cached_property
+    def app_base_model_data(self) -> tuple[str, str]:
+        """Return App Base Model data."""
+        match self.ij.model.runtime_level.lower():
+            case 'apiservice':
+                _class = 'AppApiServiceModel'
+                _file = 'app_api_service_model'
+
+            case 'feedapiservice':
+                _class = 'AppFeedApiServiceModel'
+                _file = 'app_feed_api_service_model'
+
+            case 'organization':
+                _class = 'AppOrganizationModel'
+                _file = 'app_organization_model'
+
+            case 'playbook':
+                _class = 'AppPlaybookModel'
+                _file = 'app_playbook_model'
+
+            case 'triggerservice':
+                _class = 'AppTriggerServiceModel'
+                _file = 'app_trigger_service_model'
+
+            case 'webhooktriggerservice':
+                _class = 'AppWebhookTriggerServiceModel'
+                _file = 'app_webhook_trigger_service_model'
+
+            case _:
+                Render.panel.failure(f'Invalid runtime level ({self.ij.model.runtime_level}).')
+
+        return _class, _file
+
+    @cached_property
+    def app_base_model_import(self) -> str:
+        """Return App Base Model import."""
+        _class, _file = self.app_base_model_data
+        return f'from tcex.input.model.{_file} import {_class}'
 
     @property
     def service_config_model_class_comment(self) -> str:
@@ -64,6 +91,181 @@ class GenAppInputStatic:
             ]
         )
 
+    def template_app_imports(
+        self,
+        field_type_modules: set[str],
+        pydantic_modules: set[str],
+        typing_modules: set[str],
+    ) -> list:
+        """Return app_inputs.py import data."""
+        field_types_modules_ = ', '.join(sorted(list(field_type_modules)))
+        pydantic_modules_ = ', '.join(sorted(list(pydantic_modules)))
+        typing_modules_ = ', '.join(sorted(list(typing_modules)))
+
+        # defined imports
+        _imports = ['"""App Inputs"""']
+
+        # add pyright ignore for field_type
+        _imports.append('# pyright: reportGeneralTypeIssues=false\n')
+
+        # add typing imports
+        if typing_modules:
+            _imports.append(f'from typing import {typing_modules_}')
+
+        # add pydantic imports
+        if pydantic_modules:
+            _imports.append(f'from pydantic import {pydantic_modules_}')
+
+        # add tcex Input
+        _imports.append('from tcex.input.input import Input')
+
+        # add field_type imports
+        if field_types_modules_:
+            _imports.append(f'from tcex.input.field_type import {field_types_modules_}')
+
+        # add base model import
+        _imports.append(self.app_base_model_import)
+
+        # add import for service trigger Apps
+        if self.ij.model.is_trigger_app:
+            _imports.append('from tcex.input.model import CreateConfigModel')
+
+        # add new lines
+        _imports.extend(
+            [
+                '',
+                '',
+            ]
+        )
+        return _imports
+
+    def template_app_inputs_class(self) -> list:
+        """Return app_inputs.py AppInput class."""
+        app_model = 'AppBaseModel'
+        if self.ij.model.is_trigger_app:
+            app_model = 'ServiceConfigModel'
+
+        _code = [
+            '''class AppInputs:''',
+            f'''{self.i1}"""App Inputs"""''',
+            '',
+        ]
+
+        # add __init__ method
+        _code.extend(
+            [
+                f'''{self.i1}def __init__(self, inputs: Input):''',
+                f'''{self.i2}"""Initialize instance properties."""''',
+                f'''{self.i2}self.inputs = inputs''',
+                '',
+            ]
+        )
+
+        # add update_inputs method
+        _code.extend(
+            [
+                '',
+                f'''{self.i1}def update_inputs(self):''',
+                f'''{self.i2}"""Add custom App model to inputs.''',
+                '',
+                (
+                    f'''{self.i2}Input will be validate when the '''
+                    '''model is added an any exceptions will'''
+                ),
+                f'''{self.i2}cause the App to exit with a status code of 1.''',
+                f'''{self.i2}"""''',
+                f'''{self.i2}self.inputs.add_model({app_model})''',
+                '',
+                '',
+            ]
+        )
+        return _code
+
+    def template_app_inputs_class_tc_action(self, class_model_map: dict) -> list:
+        """Return app_inputs.py AppInput class for App with tc_action."""
+        cmm = ''
+        for action, class_name in class_model_map.items():
+            action_name = action.lower().replace(' ', '_')
+            cmm += f'\'{action_name}\': {class_name},'
+        cmm = f'{{{cmm}}}'
+
+        _code = [
+            '''class AppInputs:''',
+            f'''{self.i1}"""App Inputs"""''',
+            '',
+        ]
+
+        # add __init__ method
+        _code.extend(
+            [
+                f'''{self.i1}def __init__(self, inputs: Input):''',
+                f'''{self.i2}"""Initialize instance properties."""''',
+                f'''{self.i2}self.inputs = inputs''',
+                '',
+            ]
+        )
+
+        # add action_model_map method
+        _code.extend(self.template_app_inputs_class_tc_action_model_map(cmm))
+
+        # add get_model method
+        _code.extend(
+            [
+                (
+                    f'''{self.i1}def get_model(self, tc_action: str '''
+                    '''| None = None) -> type[BaseModel]:'''
+                ),
+                f'''{self.i2}"""Return the model based on the current action."""''',
+                (
+                    f'''{self.i2}tc_action = tc_action or self.inputs.model_unresolved.tc_action'''
+                    '''  # type: ignore'''
+                ),
+                f'''{self.i2}if tc_action is None:''',
+                f'''{self.i3}raise RuntimeError('No action (tc_action) found in inputs.')''',
+                '',
+                f'''{self.i2}action_model = self.action_model_map(tc_action.lower())''',
+                f'''{self.i2}if action_model is None:''',
+                f'''{self.i3}# pylint: disable=broad-exception-raised''',
+                f'''{self.i3}raise RuntimeError(''',
+                f'''{self.i4}\'No model found for action: \'''',
+                f'''{self.i4}f'{{self.inputs.model_unresolved.tc_action}}'  # type: ignore''',
+                f'''{self.i3})''',
+                '',
+                f'''{self.i2}return action_model''',
+                '',
+            ]
+        )
+
+        # add update_inputs method
+        _code.extend(
+            [
+                f'''{self.i1}def update_inputs(self):''',
+                f'''{self.i2}"""Add custom App model to inputs.''',
+                '',
+                (
+                    f'''{self.i2}Input will be validate when the model '''
+                    '''is added an any exceptions will'''
+                ),
+                f'''{self.i2}cause the App to exit with a status code of 1.''',
+                f'''{self.i2}"""''',
+                f'''{self.i2}self.inputs.add_model(self.get_model())''',
+                '',
+                '',
+            ]
+        )
+        return _code
+
+    def template_app_inputs_class_tc_action_model_map(self, cmm: str) -> list:
+        """Return the model map method"""
+        return [
+            f'''{self.i1}def action_model_map(self, tc_action: str) -> type[BaseModel]:''',
+            f'''{self.i2}"""Return action model map."""''',
+            f'''{self.i2}_action_model_map = {cmm}''',
+            f'''{self.i2}tc_action_key = tc_action.lower().replace(' ', '_')''',
+            f'''{self.i2}return _action_model_map.get(tc_action_key)''',
+            '',
+        ]
+
     @property
     def trigger_config_model_class_comment(self) -> str:
         """Return Trigger Config Model class."""
@@ -81,72 +283,6 @@ class GenAppInputStatic:
             ]
         )
 
-    def template_app_inputs_class_tc_action(self, class_model_map: dict) -> list:
-        """Return app_inputs.py AppInput class for App with tc_action."""
-        cmm = ''
-        for action, class_name in class_model_map.items():
-            cmm += f'\'{action}\': {class_name},'
-        cmm = f'{{{cmm}}}'
-
-        return [
-            '''class AppInputs:''',
-            f'''{self.i1}"""App Inputs"""''',
-            '',
-            f'''{self.i1}def __init__(self, inputs: BaseModel):''',
-            f'''{self.i2}"""Initialize instance properties."""''',
-            f'''{self.i2}self.inputs = inputs''',
-            '',
-            f'''{self.i1}def get_model(self, tc_action: str | None = None) -> BaseModel:''',
-            f'''{self.i2}"""Return the model based on the current action."""''',
-            f'''{self.i2}tc_action = tc_action or self.inputs.model_unresolved.tc_action''',
-            f'''{self.i2}action_model_map = {cmm}''',
-            f'''{self.i2}return action_model_map.get(tc_action)''',
-            '',
-            f'''{self.i1}def update_inputs(self):''',
-            f'''{self.i2}"""Add custom App model to inputs.''',
-            '',
-            f'''{self.i2}Input will be validate when the model is added an any exceptions will''',
-            f'''{self.i2}cause the App to exit with a status code of 1.''',
-            f'''{self.i2}"""''',
-            f'''{self.i2}self.inputs.add_model(self.get_model())''',
-            '',
-            '',
-        ]
-
-    def template_app_inputs_prefix(
-        self,
-        field_type_modules: set[str],
-        pydantic_modules: set[str],
-        typing_modules: set[str],
-    ) -> list:
-        """Return app_inputs.py prefix data."""
-        field_types_modules_ = ', '.join(sorted(list(field_type_modules)))
-        pydantic_modules_ = ', '.join(sorted(list(pydantic_modules)))
-        typing_modules_ = ', '.join(sorted(list(typing_modules)))
-        _imports = [
-            '"""App Inputs"""',
-            '# pylint: disable=no-self-argument',
-            '# standard library',
-            f'from typing import {typing_modules_}',
-            '',
-            '# third-party',
-            f'from pydantic import {pydantic_modules_}',
-            f'from tcex.input.field_types import {field_types_modules_}',
-        ]
-
-        # add import for service trigger Apps
-        if self.ij.model.is_trigger_app:
-            _imports.append('from tcex.input.model import CreateConfigModel')
-
-        # add new lines
-        _imports.extend(
-            [
-                '',
-                '',
-            ]
-        )
-        return _imports
-
     @property
     def type_map(self):
         """Return input map."""
@@ -160,8 +296,8 @@ class GenAppInputStatic:
                 'required': {'type': 'binary(allow_empty=False)', 'field_type': 'binary'},
             },
             'BinaryArray': {
-                'optional': {'type': 'List[Binary]', 'field_type': 'Binary'},
-                'required': {'type': 'List[binary(allow_empty=False)]', 'field_type': 'binary'},
+                'optional': {'type': 'list[Binary]', 'field_type': 'Binary'},
+                'required': {'type': 'list[binary(allow_empty=False)]', 'field_type': 'binary'},
             },
             'Choice': {
                 'optional': {'type': 'Choice', 'field_type': 'Choice'},
@@ -180,31 +316,31 @@ class GenAppInputStatic:
                 'required': {'type': 'KeyValue', 'field_type': 'KeyValue'},
             },
             'KeyValueArray': {
-                'optional': {'type': 'List[KeyValue]', 'field_type': 'KeyValue'},
-                'required': {'type': 'List[KeyValue]', 'field_type': 'KeyValue'},
+                'optional': {'type': 'list[KeyValue]', 'field_type': 'KeyValue'},
+                'required': {'type': 'list[KeyValue]', 'field_type': 'KeyValue'},
             },
             'KeyValueList': {
-                'optional': {'type': 'List[KeyValue]', 'field_type': 'KeyValue'},
-                'required': {'type': 'List[KeyValue]', 'field_type': 'KeyValue'},
+                'optional': {'type': 'list[KeyValue]', 'field_type': 'KeyValue'},
+                'required': {'type': 'list[KeyValue]', 'field_type': 'KeyValue'},
             },
             'MultiChoice': {
-                'optional': {'type': 'List[Choice]', 'field_type': 'Choice'},
-                'required': {'type': 'List[Choice]', 'field_type': 'Choice'},
+                'optional': {'type': 'list[Choice]', 'field_type': 'Choice'},
+                'required': {'type': 'list[Choice]', 'field_type': 'Choice'},
             },
             'String': {
                 'optional': {'type': 'String', 'field_type': 'String'},
                 'required': {'type': 'string(allow_empty=False)', 'field_type': 'string'},
             },
             'StringArray': {
-                'optional': {'type': 'List[String]', 'field_type': 'String'},
-                'required': {'type': 'List[string(allow_empty=False)]', 'field_type': 'string'},
+                'optional': {'type': 'list[String]', 'field_type': 'String'},
+                'required': {'type': 'list[string(allow_empty=False)]', 'field_type': 'string'},
             },
             'TCEntity': {
                 'optional': {'type': 'TCEntity', 'field_type': 'TCEntity'},
                 'required': {'type': 'TCEntity', 'field_type': 'TCEntity'},
             },
             'TCEntityArray': {
-                'optional': {'type': 'List[TCEntity]', 'field_type': 'TCEntity'},
-                'required': {'type': 'List[TCEntity]', 'field_type': 'TCEntity'},
+                'optional': {'type': 'list[TCEntity]', 'field_type': 'TCEntity'},
+                'required': {'type': 'list[TCEntity]', 'field_type': 'TCEntity'},
             },
         }

--- a/tcex_cli/cli/spec_tool/gen_install_json.py
+++ b/tcex_cli/cli/spec_tool/gen_install_json.py
@@ -44,7 +44,7 @@ class GenInstallJson(CliABC):
                 'programMain': self.asy.model.program_main,
                 'programVersion': str(self.asy.model.program_version),
                 'runtimeLevel': self.asy.model.runtime_level,
-                'sdkVersion': tcex_version,
+                'sdkVersion': tcex_version or self.asy.model.sdk_version,
             }
         )
 

--- a/tcex_cli/cli/spec_tool/spec_tool.py
+++ b/tcex_cli/cli/spec_tool/spec_tool.py
@@ -10,8 +10,7 @@ from tcex_cli.render.render import Render
 
 def command(
     all_: bool = typer.Option(False, '--all', help='Generate all configuration files.'),
-    # TODO: the app_input logic needs to be updated for Python 3.11
-    # app_input: bool = typer.Option(False, help='Generate app_input.py.'),
+    app_input: bool = typer.Option(False, help='Generate app_input.py.'),
     app_spec: bool = typer.Option(False, help='Generate app_spec.yml.'),
     install_json: bool = typer.Option(False, help='Generate install.json.'),
     job_json: bool = typer.Option(False, help='Generate job.json.'),
@@ -41,8 +40,8 @@ def command(
             if tcex_json is True or all_ is True:
                 cli.generate_tcex_json()
 
-            # if app_input is True or all_ is True:
-            #     cli.generate_app_input()
+            if app_input is True or all_ is True:
+                cli.generate_app_input()
 
             if readme_md is True or all_ is True:
                 cli.generate_readme_md()

--- a/tcex_cli/cli/spec_tool/spec_tool_cli.py
+++ b/tcex_cli/cli/spec_tool/spec_tool_cli.py
@@ -90,15 +90,7 @@ class SpecToolCli(CliABC):
         code = gen.generate()
         self.write_app_file(gen.filename, CodeOperation.format_code('\n'.join(code)))
         if gen.report_mismatch:
-            _reports = []
-            for r in gen.report_mismatch:
-                _reports.append(
-                    {
-                        'key': 'Mismatch',
-                        'value': r,
-                    }
-                )
-            self.report_data['Mismatch Report'] = _reports
+            Render.table_mismatch('Mismatch Report', data=gen.report_mismatch)
 
     def generate_app_spec(self):
         """Generate the app_spec.yml file."""

--- a/tcex_cli/cli/template/init.py
+++ b/tcex_cli/cli/template/init.py
@@ -43,6 +43,12 @@ def command(
     """Initialize a new App from a template.
 
     Templates can be found at: https://github.com/ThreatConnect-Inc/tcex-app-templates
+
+    Optional environment variables include:\n
+    * PROXY_HOST\n
+    * PROXY_PORT\n
+    * PROXY_USER\n
+    * PROXY_PASS\n
     """
     cli = TemplateCli(
         proxy_host,

--- a/tcex_cli/cli/template/list_.py
+++ b/tcex_cli/cli/template/list_.py
@@ -34,6 +34,12 @@ def command(
     The template name will be pulled from tcex.json by default. If the template option
     is provided it will be used instead of the value in the tcex.json file. The tcex.json
     file will also be updated with new values.
+
+    Optional environment variables include:\n
+    * PROXY_HOST\n
+    * PROXY_PORT\n
+    * PROXY_USER\n
+    * PROXY_PASS\n
     """
     cli = TemplateCli(
         proxy_host,

--- a/tcex_cli/cli/template/update.py
+++ b/tcex_cli/cli/template/update.py
@@ -36,13 +36,19 @@ def command(
     proxy_user: StrOrNone = typer.Option(None, help='(Advanced) Username for the proxy server.'),
     proxy_pass: StrOrNone = typer.Option(None, help='(Advanced) Password for the proxy server.'),
 ):
-    """Update a project with the latest template files.
+    r"""Update a project with the latest template files.
 
     Templates can be found at: https://github.com/ThreatConnect-Inc/tcex-app-templates
 
     The template name will be pulled from tcex.json by default. If the template option
     is provided it will be used instead of the value in the tcex.json file. The tcex.json
     file will also be updated with new values.
+
+    Optional environment variables include:\n
+    * PROXY_HOST\n
+    * PROXY_PORT\n
+    * PROXY_USER\n
+    * PROXY_PASS\n
     """
     # external Apps do not support update
     if not Path('tcex.json').is_file():

--- a/tcex_cli/render/render.py
+++ b/tcex_cli/render/render.py
@@ -48,6 +48,64 @@ class Render(RenderUtil):
         return TextColumn('{task.description}', table_column=Column(ratio=1))
 
     @classmethod
+    def table_mismatch(
+        cls,
+        title: str,
+        data: list[dict[str, str]],
+        border_style: str = '',
+        key_style: str = 'dodger_blue1',
+        key_width: int = 20,
+        value_style: str = 'bold',
+        value_width: int = 80,
+    ):
+        """Render key/value table.
+
+        Accepts the following structuresL
+        [
+            {
+                'input': '',
+                'calculated': ''
+                'current': ''
+            }
+        ]
+        """
+        table = Table(
+            border_style=border_style,
+            expand=True,
+            show_edge=False,
+            show_header=True,
+        )
+
+        table.add_column(
+            'input',
+            justify='left',
+            max_width=key_width,
+            min_width=key_width,
+            style=key_style,
+        )
+        table.add_column(
+            'calculated',
+            justify='left',
+            max_width=value_width,
+            min_width=value_width,
+            style=value_style,
+        )
+        table.add_column(
+            'current',
+            justify='left',
+            max_width=value_width,
+            min_width=value_width,
+            style=value_style,
+        )
+
+        for item in data:
+            table.add_row(item['input'], item['calculated'], item['current'])
+
+        # render panel->table
+        if data:
+            print(Panel(table, border_style=border_style, title=title, title_align=cls.title_align))
+
+    @classmethod
     def table_package_summary(cls, title: str, summary_data: AppMetadataModel):
         """Render package summary table."""
         table = Table(


### PR DESCRIPTION
-   APP-3915 - [CONFIG] Added validation to ensure displayPath is always in the install.json for API Services
-   APP-4060 - [CLI] Updated proxy inputs to use environment variables
-   APP-4077 - [SPEC-TOOL] Updated spec-tool to create an example app_input.py file and to display a mismatch report
-   APP-4112 - [CONFIG] Updated config submodule (tcex.json model) to support legacy App Builder Apps
-   APP-4113 - [CONFIG] Updated App Spec model to normalize App features