### PR TITLE
Relax Pydantic Version Requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "jmespath",
   "paho-mqtt<2.0.0",
   "pyaes",
-  "pydantic<2.0.0",
+  "pydantic (>=1.10.17,<3.0.0)",
   "python-dateutil",
   "PyYAML",
   "redis<5.0.0",

--- a/tcex_cli/cli/model/app_metadata_model.py
+++ b/tcex_cli/cli/model/app_metadata_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class AppMetadataModel(BaseModel):

--- a/tcex_cli/cli/model/file_metadata_model.py
+++ b/tcex_cli/cli/model/file_metadata_model.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 # third-party
-from pydantic import BaseModel, Extra, Field
+from pydantic.v1 import BaseModel, Extra, Field
 
 
 class FileMetadataModel(BaseModel, extra=Extra.allow):

--- a/tcex_cli/cli/model/key_value_model.py
+++ b/tcex_cli/cli/model/key_value_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 
 class KeyValueModel(BaseModel):

--- a/tcex_cli/cli/model/validation_data_model.py
+++ b/tcex_cli/cli/model/validation_data_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class ValidationItemModel(BaseModel):

--- a/tcex_cli/cli/run/launch_abc.py
+++ b/tcex_cli/cli/run/launch_abc.py
@@ -16,7 +16,7 @@ from threading import Thread
 # third-party
 import redis
 from fakeredis import TcpFakeServer
-from pydantic import BaseModel
+from pydantic.v1 import BaseModel
 
 # first-party
 from tcex_cli.cli.run.model.common_app_input_model import CommonAppInputModel

--- a/tcex_cli/cli/run/model/api_model.py
+++ b/tcex_cli/cli/run/model/api_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument
 
 # third-party
-from pydantic import BaseSettings, Extra, validator
+from pydantic.v1 import BaseSettings, Extra, validator
 
 # first-party
 from tcex_cli.app.config.install_json import InstallJson

--- a/tcex_cli/cli/run/model/app_api_service_model.py
+++ b/tcex_cli/cli/run/model/app_api_service_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex_cli.cli.run.model.common_app_input_model import CommonAppInputModel

--- a/tcex_cli/cli/run/model/app_organization_model.py
+++ b/tcex_cli/cli/run/model/app_organization_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex_cli.cli.run.model.common_app_input_model import CommonAppInputModel

--- a/tcex_cli/cli/run/model/app_playbook_model.py
+++ b/tcex_cli/cli/run/model/app_playbook_model.py
@@ -4,7 +4,7 @@
 from pathlib import PosixPath
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex_cli.app.config import InstallJson

--- a/tcex_cli/cli/run/model/app_trigger_service_model.py
+++ b/tcex_cli/cli/run/model/app_trigger_service_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex_cli.cli.run.model.common_app_input_model import CommonAppInputModel

--- a/tcex_cli/cli/run/model/app_webhook_trigger_service_model.py
+++ b/tcex_cli/cli/run/model/app_webhook_trigger_service_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 # first-party
 from tcex_cli.cli.run.model.common_app_input_model import CommonAppInputModel

--- a/tcex_cli/cli/run/model/batch_model.py
+++ b/tcex_cli/cli/run/model/batch_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 
 class BatchModel(BaseSettings):

--- a/tcex_cli/cli/run/model/common_app_input_model.py
+++ b/tcex_cli/cli/run/model/common_app_input_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Extra
+from pydantic.v1 import BaseModel, Extra
 
 # first-party
 from tcex_cli.cli.run.model.common_model import CommonModel

--- a/tcex_cli/cli/run/model/logging_model.py
+++ b/tcex_cli/cli/run/model/logging_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 
 class LoggingModel(BaseSettings):

--- a/tcex_cli/cli/run/model/organization_model.py
+++ b/tcex_cli/cli/run/model/organization_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 
 class OrganizationModel(BaseSettings):

--- a/tcex_cli/cli/run/model/path_model.py
+++ b/tcex_cli/cli/run/model/path_model.py
@@ -4,7 +4,7 @@
 from pathlib import Path
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 
 class PathModel(BaseSettings):

--- a/tcex_cli/cli/run/model/playbook_common_model.py
+++ b/tcex_cli/cli/run/model/playbook_common_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 
 class PlaybookCommonModel(BaseSettings):

--- a/tcex_cli/cli/run/model/playbook_model.py
+++ b/tcex_cli/cli/run/model/playbook_model.py
@@ -4,7 +4,7 @@
 from uuid import uuid4
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 # first-party
 from tcex_cli.app.config.install_json import InstallJson

--- a/tcex_cli/cli/run/model/proxy_model.py
+++ b/tcex_cli/cli/run/model/proxy_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 # first-party
 from tcex_cli.input.field_type.sensitive import Sensitive

--- a/tcex_cli/cli/run/model/service_model.py
+++ b/tcex_cli/cli/run/model/service_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseSettings, Extra
+from pydantic.v1 import BaseSettings, Extra
 
 # first-party
 from tcex_cli.input.field_type.sensitive import Sensitive

--- a/tcex_cli/cli/spec_tool/spec_tool_cli.py
+++ b/tcex_cli/cli/spec_tool/spec_tool_cli.py
@@ -6,7 +6,7 @@ import shutil
 import subprocess  # nosec
 
 # third-party
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 # first-party
 from tcex_cli.app.config import AppSpecYml

--- a/tcex_cli/cli/template/model/template_config_model.py
+++ b/tcex_cli/cli/template/model/template_config_model.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=no-self-argument
 # third-party
-from pydantic import BaseModel, validator
+from pydantic.v1 import BaseModel, validator
 from semantic_version import Version
 
 

--- a/tcex_cli/cli/template/template_cli.py
+++ b/tcex_cli/cli/template/template_cli.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 # third-party
 import yaml
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 from requests import Response  # TYPE-CHECKING
 from requests import Session
 from requests.auth import HTTPBasicAuth

--- a/tcex_cli/cli/validate/validate_cli.py
+++ b/tcex_cli/cli/validate/validate_cli.py
@@ -9,7 +9,7 @@ import traceback
 from pathlib import Path
 
 # third-party
-from pydantic import ValidationError
+from pydantic.v1 import ValidationError
 
 # first-party
 from tcex_cli.app.config.job_json import JobJson

--- a/tcex_cli/input/field_type/sensitive.py
+++ b/tcex_cli/input/field_type/sensitive.py
@@ -6,7 +6,7 @@ from collections.abc import Generator
 from typing import Any, Self
 
 # third-party
-from pydantic.fields import ModelField  # TYPE-CHECKING
+from pydantic.v1.fields import ModelField  # TYPE-CHECKING
 
 # first-party
 from tcex_cli.input.field_type.exception import InvalidEmptyValue, InvalidLengthValue, InvalidType

--- a/tcex_cli/input/model/api_model.py
+++ b/tcex_cli/input/model/api_model.py
@@ -3,7 +3,7 @@
 # pylint: disable=no-self-argument
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 from ...app.config.install_json import InstallJson
 from ..field_type.sensitive import Sensitive

--- a/tcex_cli/input/model/module_app_model.py
+++ b/tcex_cli/input/model/module_app_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 from .api_model import ApiModel
 from .path_model import PathModel

--- a/tcex_cli/input/model/module_requests_session_model.py
+++ b/tcex_cli/input/model/module_requests_session_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import Extra
+from pydantic.v1 import Extra
 
 from .api_model import ApiModel
 from .proxy_model import ProxyModel

--- a/tcex_cli/input/model/path_model.py
+++ b/tcex_cli/input/model/path_model.py
@@ -5,7 +5,7 @@ import tempfile
 from pathlib import Path
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class PathModel(BaseModel):

--- a/tcex_cli/input/model/playbook_common_model.py
+++ b/tcex_cli/input/model/playbook_common_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 
 class PlaybookCommonModel(BaseModel):

--- a/tcex_cli/input/model/playbook_model.py
+++ b/tcex_cli/input/model/playbook_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field, validator
+from pydantic.v1 import BaseModel, Field, validator
 
 
 class PlaybookModel(BaseModel):

--- a/tcex_cli/input/model/proxy_model.py
+++ b/tcex_cli/input/model/proxy_model.py
@@ -1,7 +1,7 @@
 """TcEx Framework Module"""
 
 # third-party
-from pydantic import BaseModel, Field
+from pydantic.v1 import BaseModel, Field
 
 from ..field_type.sensitive import Sensitive
 


### PR DESCRIPTION
Pydantic v2 has been around for nearly 2 years, and as such many things use the new version. `tcex` and the associated repositories related to it all have a strict `<2.0.0` requirement on Pydantic, which is problematic when trying to utilize these libraries in a larger application or ecosystem which uses a newer version of Pydantic.

This PR and a collection of others I am in the process of making together aim to relax the version requirements for Pydantic by utilizing the `pydantic.v1` namespace introduced in `v1.10.17`. This `pyandic.v1` namespace allows users to utilize Pydantic as it was in v1 even when v2 is installed. It is explicitly listed as an option in the official [Migration Guide](https://docs.pydantic.dev/latest/migration/#using-pydantic-v1-features-in-a-v1v2-environment).

I plan to place this same PR description across all repositories which I found that needed updating, so here's some overarching information about this process as I have been able to understand it:

1. There are three "primary" projects which define Python packages: `tcex`, `tcex-cli`, and `tcex-app-testing`.
2. The primary projects need their `pyproject.toml` updated to relax the requirements to `>=1.10.17,<3.0.0`.
3. Secondary projects are used as submodules within the primary projects. The submodule projects that have references to pydantic are (as far as I could find): `tcex-app-config`, `tcex-app-playbook`, `tcex-util`.
4. All projects (primary and secondary) need all references to importing `pydantic` updated to reference `pydantic.v1`.

This is all relatively straightforward. In the forks I have made, I've run the following straightforward one-liner to replace all `from pydantic...` lines appropriately:

```sh
find . -name '*.py' | while read filepath; do
  sed 's/^from pydantic/from pydantic.v1/g' -i "$filepath"
done
```

For repositories with submodules (the primary repositories mentioned above), I filtered out the submodule paths before making this replacement. After the secondary repositories are merged, the primary repository submodules will also need to be updated to account for these changes in the primary repositories as well.

I will be the first to admit that I am not the best person to test all of this as I'm not intimately familiar with `tcex` or all the in's and out's of your application(s). But I am familiar with Pydantic, and this version conflict is a bump in the road for me, so I'm happy to work through troubleshooting. I'm happy to discuss options and work with the team, but given that this was just a bunch of find-and-replace followed by careful coordination of submodules, I figured I'd at least get the ball rolling.

Once all six of the PRs are open, I'll go back through and make a comment on each to reference the others so they can be properly tracked/linked.