### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
   "rich>=13.9.4",
   "semantic-version>=2.10.0",
   "tinydb>=4.8.2",
-  "typer>=0.15.1",
+  "typer>=0.15.1,<0.24.1",
   "wrapt>=1.17.2",
 ]
 


### PR DESCRIPTION
Pin typer dependency to avoid release 0.24.1, which breaks